### PR TITLE
Readme and package.json changes for block fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-<h1><p align="center"><img alt="protobuf.js" src="https://github.com/protobufjs/protobuf.js/raw/master/pbjs.svg" height="100" /><br/>protobuf.js</p></h1>
-<p align="center">
-  <a href="https://github.com/protobufjs/protobuf.js/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/protobufjs/protobuf.js/test.yml?branch=master&label=build&logo=github" alt=""></a>
-  <a href="https://github.com/protobufjs/protobuf.js/actions/workflows/release.yaml"><img src="https://img.shields.io/github/actions/workflow/status/protobufjs/protobuf.js/release.yaml?branch=master&label=release&logo=github" alt=""></a>
-  <a href="https://npmjs.org/package/protobufjs"><img src="https://img.shields.io/npm/v/protobufjs.svg?logo=npm" alt=""></a>
-  <a href="https://npmjs.org/package/protobufjs"><img src="https://img.shields.io/npm/dm/protobufjs.svg?label=downloads&logo=npm" alt=""></a>
-  <a href="https://www.jsdelivr.com/package/npm/protobufjs"><img src="https://img.shields.io/jsdelivr/npm/hm/protobufjs?label=requests&logo=jsdelivr" alt=""></a>
-</p>
+Fork
+--------
+
+A fork of protobuf.js providing performance improvements when using large proto graphs and `addJSON` for ingestion.
+
+protobuf.js
+--------
 
 **Protocol Buffers** are a language-neutral, platform-neutral, extensible way of serializing structured data for use in communications protocols, data storage, and more, originally designed at Google ([see](https://protobuf.dev/)).
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
-  "name": "protobufjs",
-  "version": "7.5.3",
+  "name": "@square/protobufjs",
+  "version": "7.6.0-square.alpha.0",
   "versionScheme": "~",
   "description": "Protocol Buffers for JavaScript (& TypeScript).",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",
+  "contributors": [
+    "Ray Cohen <rcohen@squareup.com>"
+  ],
   "license": "BSD-3-Clause",
-  "repository": "protobufjs/protobuf.js",
-  "bugs": "https://github.com/protobufjs/protobuf.js/issues",
-  "homepage": "https://protobufjs.github.io/protobuf.js/",
+  "repository": "block/protobuf.js",
+  "bugs": "https://github.com/block/protobuf.js/issues",
   "engines": {
     "node": ">=12.0.0"
   },
@@ -20,6 +22,7 @@
     }
   },
   "keywords": [
+    "fork",
     "protobuf",
     "protocol-buffers",
     "serialization",


### PR DESCRIPTION
- Uses the [@square npm scope](https://www.npmjs.com/org/square)
- Update Readme with fork info
- Update some package.json fields
- This PR targets the new `block-master` branch

My plan is to keep this repo's `master` branch in sync with upstream master (mainly since gh makes this easy) and use the `block-master` branch to hold our publishing config. Feature change branches will be PR'd both into `block-master` and against the upstream https://github.com/protobufjs/protobuf.js project.