### PR TITLE
Fix: avoid extra recursion in namespace add

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -133,14 +133,16 @@ function Namespace(name, options) {
     this._needsRecursiveResolve = true;
 }
 
-function clearCache(namespace) {
+function clearCache(namespace, skipRecursiveCleanup) {
     namespace._nestedArray = null;
     namespace._lookupCache = {};
 
-    // Also clear parent caches, since they include nested lookups.
-    var parent = namespace;
-    while(parent = parent.parent) {
-        parent._lookupCache = {};
+    if (!skipRecursiveCleanup) {
+        // Also clear parent caches, since they include nested lookups.
+        var parent = namespace;
+        while(parent = parent.parent) {
+            parent._lookupCache = {};
+        }
     }
     return namespace;
 }
@@ -241,11 +243,12 @@ Namespace.prototype.getEnum = function getEnum(name) {
 /**
  * Adds a nested object to this namespace.
  * @param {ReflectionObject} object Nested object to add
+ * @param {boolean} [skipRecursiveSetup] If `true`, does not set up recursive features
  * @returns {Namespace} `this`
  * @throws {TypeError} If arguments are invalid
  * @throws {Error} If there is already a nested object with this name
  */
-Namespace.prototype.add = function add(object) {
+Namespace.prototype.add = function add(object, skipRecursiveSetup) {
 
     if (!(object instanceof Field && object.extend !== undefined || object instanceof Type  || object instanceof OneOf || object instanceof Enum || object instanceof Service || object instanceof Namespace))
         throw TypeError("object must be a valid nested object");
@@ -259,8 +262,8 @@ Namespace.prototype.add = function add(object) {
                 // replace plain namespace but keep existing nested elements and options
                 var nested = prev.nestedArray;
                 for (var i = 0; i < nested.length; ++i)
-                    object.add(nested[i]);
-                this.remove(prev);
+                    object.add(nested[i], true);
+                this.remove(prev, true);
                 if (!this.nested)
                     this.nested = {};
                 object.setOptions(prev.options, true);
@@ -282,25 +285,28 @@ Namespace.prototype.add = function add(object) {
     this._needsRecursiveFeatureResolution = true;
     this._needsRecursiveResolve = true;
 
-    // Also clear parent caches, since they need to recurse down.
-    var parent = this;
-    while(parent = parent.parent) {
-        parent._needsRecursiveFeatureResolution = true;
-        parent._needsRecursiveResolve = true;
+    if (!skipRecursiveSetup) {
+        // Also clear parent caches, since they need to recurse down.
+        var parent = this;
+        while(parent = parent.parent) {
+            parent._needsRecursiveFeatureResolution = true;
+            parent._needsRecursiveResolve = true;
+        }
     }
-
-    object.onAdd(this);
-    return clearCache(this);
+    object.onAdd(this, skipRecursiveSetup);
+    clearCache(this, skipRecursiveSetup);
+    return this;
 };
 
 /**
  * Removes a nested object from this namespace.
  * @param {ReflectionObject} object Nested object to remove
+ * @param {boolean} [skipRecursiveCleanup] If `true`, does not perform recursive cleanup
  * @returns {Namespace} `this`
  * @throws {TypeError} If arguments are invalid
  * @throws {Error} If `object` is not a member of this namespace
  */
-Namespace.prototype.remove = function remove(object) {
+Namespace.prototype.remove = function remove(object, skipRecursiveCleanup) {
 
     if (!(object instanceof ReflectionObject))
         throw TypeError("object must be a ReflectionObject");
@@ -310,9 +316,9 @@ Namespace.prototype.remove = function remove(object) {
     delete this.nested[object.name];
     if (!Object.keys(this.nested).length)
         this.nested = undefined;
-
-    object.onRemove(this);
-    return clearCache(this);
+    object.onRemove(this, skipRecursiveCleanup);
+    clearCache(this, skipRecursiveCleanup);
+    return this;
 };
 
 /**

--- a/src/object.js
+++ b/src/object.js
@@ -150,27 +150,34 @@ ReflectionObject.prototype.toJSON = /* istanbul ignore next */ function toJSON()
 /**
  * Called when this object is added to a parent.
  * @param {ReflectionObject} parent Parent added to
+ * @param {boolean} [skipRecursiveSetup] If `true`, does not set up recursive features
  * @returns {undefined}
  */
-ReflectionObject.prototype.onAdd = function onAdd(parent) {
+ReflectionObject.prototype.onAdd = function onAdd(parent, skipRecursiveSetup) {
     if (this.parent && this.parent !== parent)
-        this.parent.remove(this);
+        this.parent.remove(this, skipRecursiveSetup);
     this.parent = parent;
     this.resolved = false;
-    var root = parent.root;
-    if (root instanceof Root)
-        root._handleAdd(this);
+
+    if (!skipRecursiveSetup) {
+        var root = parent.root;
+        if (root instanceof Root)
+            root._handleAdd(this);
+    }
 };
 
 /**
  * Called when this object is removed from a parent.
  * @param {ReflectionObject} parent Parent removed from
+ * @param {boolean} [skipRecursiveCleanup] If `true`, does not clean up recursive caches
  * @returns {undefined}
  */
-ReflectionObject.prototype.onRemove = function onRemove(parent) {
-    var root = parent.root;
-    if (root instanceof Root)
-        root._handleRemove(this);
+ReflectionObject.prototype.onRemove = function onRemove(parent, skipRecursiveCleanup) {
+    if (!skipRecursiveCleanup) {
+        var root = parent.root;
+        if (root instanceof Root)
+            root._handleRemove(this);
+    }
     this.parent = null;
     this.resolved = false;
 };

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -129,5 +129,122 @@ tape.test("reflected namespaces", function(test) {
         }
     }, "should create from Type, Enum, Service, extension Field and Namespace JSON");
 
+    root = new protobuf.Root();
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        Message: {
+                            fields: {
+                                amount: { type: "int32", id: 2 },
+                                code: { type: "string", id: 3 }
+                            }
+                        },
+                        Service: {
+                            methods: {
+                                MakeUpdate: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessage: { fields: {} }
+            }
+        }
+    });
+
+    // store these before calling `addJSON` the second time
+    var originalOuter = root.lookup('outer');
+    var originalInner = originalOuter.lookup('inner');
+    var originalMessage = originalInner.lookup('Message');
+    var originalService = originalInner.lookup('Service');
+    var originalOuterMessage = originalOuter.lookup('OuterMessage');
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        MessageTwo: {
+                            fields: {
+                                amountTwo: { type: "int32", id: 5 },
+                                codeTwo: { type: "string", id: 6 }
+                            }
+                        },
+                        ServiceTwo: {
+                            methods: {
+                                MakeUpdateTwo: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessageTwo: { fields: {} }
+            }
+        }
+    });
+
+    test.same(root.toJSON().nested.outer, {
+        nested: {
+            inner: {
+                nested: {
+                    Message: {
+                        fields: {
+                            amount: { type: "int32", id: 2 },
+                            code: { type: "string", id: 3 }
+                        }
+                    },
+                    Service: {
+                        methods: {
+                            MakeUpdate: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    },
+                    MessageTwo: {
+                        fields: {
+                            amountTwo: { type: "int32", id: 5 },
+                            codeTwo: { type: "string", id: 6 }
+                        }
+                    },
+                    ServiceTwo: {
+                        methods: {
+                            MakeUpdateTwo: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    }
+                }
+            },
+            OuterMessage: { fields: {} },
+            OuterMessageTwo: { fields: {} }
+        },
+    }, "should merge deeply nested namespaces");
+
+    // These leaf objects should not be changed by the above merge as they do not conflict
+    test.equal(originalMessage, root.lookup("outer.inner.Message"), "inner.Message not be changed by merge");
+    test.equal(originalService, root.lookup("outer.inner.Service"), "inner.Service not be changed by merge");
+    test.equal(originalOuterMessage, root.lookup("outer.OuterMessage"), "OuterMessage not be changed by merge");
+
+    // Note: these assertions cover an implementation detail. Right now, the Namespace.add recursion
+    // alternates between the original Namespace and the new Namespace at each level of merging.
+    // In our case, the original `outer` is replaced by the new `outer`, but the `inner` namespace remains the same.
+    test.notEqual(originalOuter, root.lookup("outer"), "outer should be changed after merging");
+    test.equal(originalInner, root.lookup("outer.inner"), "inner should not be changed after merging");
+
+    test.equal(originalOuter.parent, null, "removed outer namespace should not have a parent");
+    test.equal(originalInner.parent, root.lookup("outer"), "unremoved inner namespace's parent is the current outer namespace");
+
+    test.equal(originalOuter.lookup("inner"), null, "removed outer should not be able to look up an inner namespace");
+    test.equal(originalOuter.lookup("OuterMessage"), null, "removed outer should not be able to look up an OuterMessage");
+
     test.end();
 });


### PR DESCRIPTION
## Background

Our legacy frontend monolith's current use of protobuf.js has us calling `addJSON` with large json schema objects hundreds or even thousands of times in a page load. 

The logic in `Namespace#add` recurses directly on matching namespaces, which we hit often because every json schema object we add in begins at the root level, and most of our protos share a few levels of namespace before they get to interesting objects.

In addition to `Namespace#add`'s _explicit_ recursion, it _also_ calls into other methods that recurse. The result is an explosion of recursion that is one of the top places our app spends time when booting or when switching routes into a route that loads additional proto schema info.

## Changes

This PR changes `Namespace#add` and downstream methods so that only the top frame in its own recursion tells downstream methods to perform _their_ recursion. The intent is for this to significantly reduce the amount of work we do while calling `addJSON` repeatedly, but without breaking anything.