### PR TITLE
chore: change Namespace.add to always merge into Namespaces already in graph

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -257,13 +257,13 @@ Namespace.prototype.add = function add(object) {
         if (prev) {
             if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
                 // replace plain namespace but keep existing nested elements and options
-                var nested = prev.nestedArray;
+                var nested = object.nestedArray;
                 for (var i = 0; i < nested.length; ++i)
-                    object.add(nested[i]);
-                this.remove(prev);
+                    prev.add(nested[i]);
+                if (object.parent) object.parent.remove(object);
                 if (!this.nested)
                     this.nested = {};
-                object.setOptions(prev.options, true);
+                prev.setOptions(object.options, true);
 
             } else
                 throw Error("duplicate name '" + object.name + "' in " + this);


### PR DESCRIPTION
For a call like

```js
leftNamespace.add(rightNamespace)
```

the current logic will merge immediate children of the "left" namespace into matches found in the right namespace. It then makes the recursive `add` call flipping the children for the "right" namespace to be the "left".

The resulting merged graph has odd level children from the `rightNamespace` graph and even level children from the `leftNamespace` graph

```
leftNamespace
 -> Level 1 namespace children from rightNamespace graph
 -> Level 2 namespace children from leftNameSpace graph
 -> Level 3 namespace children from rightNamespace graph
 -> Level 4 namespace children from leftNameSpace graph
 ...
```

This works, but it seems more confusing than keeping the left side always the left, if only because equality checks in tests when working with recursive `add` operations won't require the test to understand the even/odd flipping