### PR TITLE
Fix: avoid extra recursion in namespace add

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -766,20 +766,22 @@ export abstract class NamespaceBase extends ReflectionObject {
     /**
      * Adds a nested object to this namespace.
      * @param object Nested object to add
+     * @param [skipRecursiveSetup] If `true`, does not set up recursive features
      * @returns `this`
      * @throws {TypeError} If arguments are invalid
      * @throws {Error} If there is already a nested object with this name
      */
-    public add(object: ReflectionObject): Namespace;
+    public add(object: ReflectionObject, skipRecursiveSetup?: boolean): Namespace;
 
     /**
      * Removes a nested object from this namespace.
      * @param object Nested object to remove
+     * @param [skipRecursiveCleanup] If `true`, does not perform recursive cleanup
      * @returns `this`
      * @throws {TypeError} If arguments are invalid
      * @throws {Error} If `object` is not a member of this namespace
      */
-    public remove(object: ReflectionObject): Namespace;
+    public remove(object: ReflectionObject, skipRecursiveCleanup?: boolean): Namespace;
 
     /**
      * Defines additial namespaces within this one if not yet existing.
@@ -904,14 +906,16 @@ export abstract class ReflectionObject {
     /**
      * Called when this object is added to a parent.
      * @param parent Parent added to
+     * @param [skipRecursiveSetup] If `true`, does not set up recursive features
      */
-    public onAdd(parent: ReflectionObject): void;
+    public onAdd(parent: ReflectionObject, skipRecursiveSetup?: boolean): void;
 
     /**
      * Called when this object is removed from a parent.
      * @param parent Parent removed from
+     * @param [skipRecursiveCleanup] If `true`, does not perform recursive cleanup
      */
-    public onRemove(parent: ReflectionObject): void;
+    public onRemove(parent: ReflectionObject, skipRecursiveCleanup?: boolean): void;
 
     /**
      * Resolves this objects type references.

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -110,7 +110,7 @@ function Namespace(name, options) {
     this._nestedArray = null;
 }
 
-function clearCache(namespace, skipRecursiveCleanup) {
+function clearCache(namespace) {
     namespace._nestedArray = null;
     return namespace;
 }
@@ -245,10 +245,11 @@ Namespace.prototype.add = function add(object, skipRecursiveSetup) {
                 throw Error("duplicate name '" + object.name + "' in " + this);
         }
     }
+
     if (!merged) {
         this.nested[object.name] = object;
         object.onAdd(this, skipRecursiveSetup);
-        clearCache(this, skipRecursiveSetup);
+        clearCache(this);
     }
     return this;
 };
@@ -271,9 +272,9 @@ Namespace.prototype.remove = function remove(object, skipRecursiveCleanup) {
     delete this.nested[object.name];
     if (!Object.keys(this.nested).length)
         this.nested = undefined;
+
     object.onRemove(this, skipRecursiveCleanup);
-    clearCache(this, skipRecursiveCleanup);
-    return this;
+    return clearCache(this);
 };
 
 /**

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -110,7 +110,7 @@ function Namespace(name, options) {
     this._nestedArray = null;
 }
 
-function clearCache(namespace) {
+function clearCache(namespace, skipRecursiveCleanup) {
     namespace._nestedArray = null;
     return namespace;
 }
@@ -211,10 +211,10 @@ Namespace.prototype.getEnum = function getEnum(name) {
 function mergeNamespaces({ recipient, donor }) {
     var nested = donor.nestedArray;
     for (var i = 0; i < nested.length; ++i) {
-        recipient.add(nested[i]);
+        recipient.add(nested[i], true);
     }
     if (donor.parent) {
-        donor.parent.remove(donor);
+        donor.parent.remove(donor, true);
     }
     recipient.setOptions(donor.options, true);
 }
@@ -222,11 +222,12 @@ function mergeNamespaces({ recipient, donor }) {
 /**
  * Adds a nested object to this namespace.
  * @param {ReflectionObject} object Nested object to add
+ * @param {boolean} [skipRecursiveSetup] If `true`, does not set up recursive features
  * @returns {Namespace} `this`
  * @throws {TypeError} If arguments are invalid
  * @throws {Error} If there is already a nested object with this name
  */
-Namespace.prototype.add = function add(object) {
+Namespace.prototype.add = function add(object, skipRecursiveSetup) {
 
     if (!(object instanceof Field && object.extend !== undefined || object instanceof Type  || object instanceof OneOf || object instanceof Enum || object instanceof Service || object instanceof Namespace))
         throw TypeError("object must be a valid nested object");
@@ -244,11 +245,10 @@ Namespace.prototype.add = function add(object) {
                 throw Error("duplicate name '" + object.name + "' in " + this);
         }
     }
-
     if (!merged) {
         this.nested[object.name] = object;
-        object.onAdd(this);
-        clearCache(this);
+        object.onAdd(this, skipRecursiveSetup);
+        clearCache(this, skipRecursiveSetup);
     }
     return this;
 };
@@ -256,11 +256,12 @@ Namespace.prototype.add = function add(object) {
 /**
  * Removes a nested object from this namespace.
  * @param {ReflectionObject} object Nested object to remove
+ * @param {boolean} [skipRecursiveCleanup] If `true`, does not perform recursive cleanup
  * @returns {Namespace} `this`
  * @throws {TypeError} If arguments are invalid
  * @throws {Error} If `object` is not a member of this namespace
  */
-Namespace.prototype.remove = function remove(object) {
+Namespace.prototype.remove = function remove(object, skipRecursiveCleanup) {
 
     if (!(object instanceof ReflectionObject))
         throw TypeError("object must be a ReflectionObject");
@@ -270,9 +271,9 @@ Namespace.prototype.remove = function remove(object) {
     delete this.nested[object.name];
     if (!Object.keys(this.nested).length)
         this.nested = undefined;
-
-    object.onRemove(this);
-    return clearCache(this);
+    object.onRemove(this, skipRecursiveCleanup);
+    clearCache(this, skipRecursiveCleanup);
+    return this;
 };
 
 /**

--- a/src/object.js
+++ b/src/object.js
@@ -114,27 +114,34 @@ ReflectionObject.prototype.toJSON = /* istanbul ignore next */ function toJSON()
 /**
  * Called when this object is added to a parent.
  * @param {ReflectionObject} parent Parent added to
+ * @param {boolean} [skipRecursiveSetup] If `true`, does not set up recursive features
  * @returns {undefined}
  */
-ReflectionObject.prototype.onAdd = function onAdd(parent) {
+ReflectionObject.prototype.onAdd = function onAdd(parent, skipRecursiveSetup) {
     if (this.parent && this.parent !== parent)
-        this.parent.remove(this);
+        this.parent.remove(this, skipRecursiveSetup);
     this.parent = parent;
     this.resolved = false;
-    var root = parent.root;
-    if (root instanceof Root)
-        root._handleAdd(this);
+
+    if (!skipRecursiveSetup) {
+        var root = parent.root;
+        if (root instanceof Root)
+            root._handleAdd(this);
+    }
 };
 
 /**
  * Called when this object is removed from a parent.
  * @param {ReflectionObject} parent Parent removed from
+ * @param {boolean} [skipRecursiveCleanup] If `true`, does not clean up recursive caches
  * @returns {undefined}
  */
-ReflectionObject.prototype.onRemove = function onRemove(parent) {
-    var root = parent.root;
-    if (root instanceof Root)
-        root._handleRemove(this);
+ReflectionObject.prototype.onRemove = function onRemove(parent, skipRecursiveCleanup) {
+    if (!skipRecursiveCleanup) {
+        var root = parent.root;
+        if (root instanceof Root)
+            root._handleRemove(this);
+    }
     this.parent = null;
     this.resolved = false;
 };

--- a/src/object.js
+++ b/src/object.js
@@ -125,22 +125,24 @@ ReflectionObject.prototype.onAdd = function onAdd(parent, skipRecursiveSetup) {
 
     if (!skipRecursiveSetup) {
         var root = parent.root;
-        if (root instanceof Root)
+        if (root instanceof Root) {
             root._handleAdd(this);
+        }
     }
 };
 
 /**
  * Called when this object is removed from a parent.
  * @param {ReflectionObject} parent Parent removed from
- * @param {boolean} [skipRecursiveCleanup] If `true`, does not clean up recursive caches
+ * @param {boolean} [skipRecursiveCleanup] If `true`, does not perform recursive cleanup
  * @returns {undefined}
  */
 ReflectionObject.prototype.onRemove = function onRemove(parent, skipRecursiveCleanup) {
     if (!skipRecursiveCleanup) {
         var root = parent.root;
-        if (root instanceof Root)
+        if (root instanceof Root) {
             root._handleRemove(this);
+        }
     }
     this.parent = null;
     this.resolved = false;

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -129,123 +129,6 @@ tape.test("reflected namespaces", function(test) {
         }
     }, "should create from Type, Enum, Service, extension Field and Namespace JSON");
 
-    root = new protobuf.Root();
-
-    root.addJSON({
-        outer: {
-            nested: {
-                inner: {
-                    nested: {
-                        Message: {
-                            fields: {
-                                amount: { type: "int32", id: 2 },
-                                code: { type: "string", id: 3 }
-                            }
-                        },
-                        Service: {
-                            methods: {
-                                MakeUpdate: {
-                                    requestType: "ExampleRequest",
-                                    responseType: "ExampleResponse"
-                                }
-                            }
-                        },
-                    }
-                },
-                OuterMessage: { fields: {} }
-            }
-        }
-    });
-
-    // store these before calling `addJSON` the second time
-    var originalOuter = root.lookup('outer');
-    var originalInner = originalOuter.lookup('inner');
-    var originalMessage = originalInner.lookup('Message');
-    var originalService = originalInner.lookup('Service');
-    var originalOuterMessage = originalOuter.lookup('OuterMessage');
-
-    root.addJSON({
-        outer: {
-            nested: {
-                inner: {
-                    nested: {
-                        MessageTwo: {
-                            fields: {
-                                amountTwo: { type: "int32", id: 5 },
-                                codeTwo: { type: "string", id: 6 }
-                            }
-                        },
-                        ServiceTwo: {
-                            methods: {
-                                MakeUpdateTwo: {
-                                    requestType: "ExampleRequest",
-                                    responseType: "ExampleResponse"
-                                }
-                            }
-                        },
-                    }
-                },
-                OuterMessageTwo: { fields: {} }
-            }
-        }
-    });
-
-    test.same(root.toJSON().nested.outer, {
-        nested: {
-            inner: {
-                nested: {
-                    Message: {
-                        fields: {
-                            amount: { type: "int32", id: 2 },
-                            code: { type: "string", id: 3 }
-                        }
-                    },
-                    Service: {
-                        methods: {
-                            MakeUpdate: {
-                                requestType: "ExampleRequest",
-                                responseType: "ExampleResponse"
-                            }
-                        }
-                    },
-                    MessageTwo: {
-                        fields: {
-                            amountTwo: { type: "int32", id: 5 },
-                            codeTwo: { type: "string", id: 6 }
-                        }
-                    },
-                    ServiceTwo: {
-                        methods: {
-                            MakeUpdateTwo: {
-                                requestType: "ExampleRequest",
-                                responseType: "ExampleResponse"
-                            }
-                        }
-                    }
-                }
-            },
-            OuterMessage: { fields: {} },
-            OuterMessageTwo: { fields: {} }
-        },
-    }, "should merge deeply nested namespaces");
-
-    // These leaf objects should not be changed by the above merge as they do not conflict
-    test.equal(originalMessage, root.lookup("outer.inner.Message"), "inner.Message not be changed by merge");
-    test.equal(originalService, root.lookup("outer.inner.Service"), "inner.Service not be changed by merge");
-    test.equal(originalOuterMessage, root.lookup("outer.OuterMessage"), "OuterMessage not be changed by merge");
-
-    // Note: these assertions cover an implementation detail. Right now, the Namespace.add recursion
-    // alternates between the original Namespace and the new Namespace at each level of merging.
-    // In our case, the original `outer` is replaced by the new `outer`, but the `inner` namespace remains the same.
-    test.notEqual(originalOuter, root.lookup("outer"), "outer should be changed after merging");
-    test.equal(originalInner, root.lookup("outer.inner"), "inner should not be changed after merging");
-
-    test.equal(originalOuter.parent, null, "removed outer namespace should not have a parent");
-    test.equal(originalInner.parent, root.lookup("outer"), "unremoved inner namespace's parent is the current outer namespace");
-
-    test.equal(originalOuter.lookup("inner"), null, "removed outer should not be able to look up an inner namespace");
-    test.equal(originalOuter.lookup("OuterMessage"), null, "removed outer should not be able to look up an OuterMessage");
-
     test.end();
 });
 
@@ -332,6 +215,115 @@ tape.test("namespace merging with nested namespaces", function(test) {
     test.equal(org2.parent, companyOriginal, "org2 parent is now companyOriginal");
     test.equal(squad.parent, org2, "squad parent is still org2");
     test.same(root.lookup('company.org2.squad'), squad, "the squad object is accessible from root");
+
+    // Begin testing deeply nested namespaces
+    root = new protobuf.Root();
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        Message: {
+                            fields: {
+                                amount: { type: "int32", id: 2 },
+                                code: { type: "string", id: 3 }
+                            }
+                        },
+                        Service: {
+                            methods: {
+                                MakeUpdate: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessage: { fields: {} }
+            }
+        }
+    });
+
+    // store these before calling `addJSON` the second time
+    var originalOuter = root.lookup('outer');
+    var originalInner = originalOuter.lookup('inner');
+    var originalMessage = originalInner.lookup('Message');
+    var originalService = originalInner.lookup('Service');
+    var originalOuterMessage = originalOuter.lookup('OuterMessage');
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        MessageTwo: {
+                            fields: {
+                                amountTwo: { type: "int32", id: 5 },
+                                codeTwo: { type: "string", id: 6 }
+                            }
+                        },
+                        ServiceTwo: {
+                            methods: {
+                                MakeUpdateTwo: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessageTwo: { fields: {} }
+            }
+        }
+    });
+
+    // Verify that the merged structure is as expected
+    test.same(root.toJSON().nested.outer, {
+        nested: {
+            inner: {
+                nested: {
+                    Message: {
+                        fields: {
+                            amount: { type: "int32", id: 2 },
+                            code: { type: "string", id: 3 }
+                        }
+                    },
+                    Service: {
+                        methods: {
+                            MakeUpdate: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    },
+                    MessageTwo: {
+                        fields: {
+                            amountTwo: { type: "int32", id: 5 },
+                            codeTwo: { type: "string", id: 6 }
+                        }
+                    },
+                    ServiceTwo: {
+                        methods: {
+                            MakeUpdateTwo: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    }
+                }
+            },
+            OuterMessage: { fields: {} },
+            OuterMessageTwo: { fields: {} }
+        },
+    }, "should merge deeply nested namespaces");
+
+    // Verify that the original namespaces references are still accessible via lookup from root
+    test.equal(originalOuter, root.lookup("outer"), "outer ref unchanged by merge");
+    test.equal(originalInner, root.lookup("outer.inner"), "inner ref unchanged by merge");
+    test.equal(originalMessage, root.lookup("outer.inner.Message"), "inner.Message ref unchanged by merge");
+    test.equal(originalService, root.lookup("outer.inner.Service"), "inner.Service ref unchanged by merge");
+    test.equal(originalOuterMessage, root.lookup("outer.OuterMessage"), "OuterMessage ref unchanged by merge");
 
     test.end();
 });

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -129,6 +129,123 @@ tape.test("reflected namespaces", function(test) {
         }
     }, "should create from Type, Enum, Service, extension Field and Namespace JSON");
 
+    root = new protobuf.Root();
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        Message: {
+                            fields: {
+                                amount: { type: "int32", id: 2 },
+                                code: { type: "string", id: 3 }
+                            }
+                        },
+                        Service: {
+                            methods: {
+                                MakeUpdate: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessage: { fields: {} }
+            }
+        }
+    });
+
+    // store these before calling `addJSON` the second time
+    var originalOuter = root.lookup('outer');
+    var originalInner = originalOuter.lookup('inner');
+    var originalMessage = originalInner.lookup('Message');
+    var originalService = originalInner.lookup('Service');
+    var originalOuterMessage = originalOuter.lookup('OuterMessage');
+
+    root.addJSON({
+        outer: {
+            nested: {
+                inner: {
+                    nested: {
+                        MessageTwo: {
+                            fields: {
+                                amountTwo: { type: "int32", id: 5 },
+                                codeTwo: { type: "string", id: 6 }
+                            }
+                        },
+                        ServiceTwo: {
+                            methods: {
+                                MakeUpdateTwo: {
+                                    requestType: "ExampleRequest",
+                                    responseType: "ExampleResponse"
+                                }
+                            }
+                        },
+                    }
+                },
+                OuterMessageTwo: { fields: {} }
+            }
+        }
+    });
+
+    test.same(root.toJSON().nested.outer, {
+        nested: {
+            inner: {
+                nested: {
+                    Message: {
+                        fields: {
+                            amount: { type: "int32", id: 2 },
+                            code: { type: "string", id: 3 }
+                        }
+                    },
+                    Service: {
+                        methods: {
+                            MakeUpdate: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    },
+                    MessageTwo: {
+                        fields: {
+                            amountTwo: { type: "int32", id: 5 },
+                            codeTwo: { type: "string", id: 6 }
+                        }
+                    },
+                    ServiceTwo: {
+                        methods: {
+                            MakeUpdateTwo: {
+                                requestType: "ExampleRequest",
+                                responseType: "ExampleResponse"
+                            }
+                        }
+                    }
+                }
+            },
+            OuterMessage: { fields: {} },
+            OuterMessageTwo: { fields: {} }
+        },
+    }, "should merge deeply nested namespaces");
+
+    // These leaf objects should not be changed by the above merge as they do not conflict
+    test.equal(originalMessage, root.lookup("outer.inner.Message"), "inner.Message not be changed by merge");
+    test.equal(originalService, root.lookup("outer.inner.Service"), "inner.Service not be changed by merge");
+    test.equal(originalOuterMessage, root.lookup("outer.OuterMessage"), "OuterMessage not be changed by merge");
+
+    // Note: these assertions cover an implementation detail. Right now, the Namespace.add recursion
+    // alternates between the original Namespace and the new Namespace at each level of merging.
+    // In our case, the original `outer` is replaced by the new `outer`, but the `inner` namespace remains the same.
+    test.notEqual(originalOuter, root.lookup("outer"), "outer should be changed after merging");
+    test.equal(originalInner, root.lookup("outer.inner"), "inner should not be changed after merging");
+
+    test.equal(originalOuter.parent, null, "removed outer namespace should not have a parent");
+    test.equal(originalInner.parent, root.lookup("outer"), "unremoved inner namespace's parent is the current outer namespace");
+
+    test.equal(originalOuter.lookup("inner"), null, "removed outer should not be able to look up an inner namespace");
+    test.equal(originalOuter.lookup("OuterMessage"), null, "removed outer should not be able to look up an OuterMessage");
+
     test.end();
 });
 


### PR DESCRIPTION
## Background

Our legacy frontend monolith's current use of protobuf.js has us calling `addJSON` with large json schema objects hundreds or even thousands of times in a page load. 

The logic in `Namespace#add` recurses directly on matching namespaces, which we hit often because every json schema object we add in begins at the root level, and most of our protos share a few levels of namespace before they get to interesting objects.

In addition to `Namespace#add`'s _own_ recursion (via the `mergeNamespaces` helper), it also calls into other methods that recurse. The result is an explosion of recursion that is one of the top places our app spends time when booting or when switching routes into a route that loads additional proto schema info.

## Changes

This PR changes `Namespace#add` and downstream methods so that only the top frame in its own recursion tells downstream methods to perform _their_ recursion. The intent is for this to significantly reduce the amount of work we do while calling `addJSON` repeatedly, but without breaking anything.

In local testing, this dropped time spent in `addJSON` from `377ms` to `19.8ms`:
<img width="424" height="343" alt="Screenshot 2025-08-11 at 1 03 24 PM" src="https://github.com/user-attachments/assets/16503f0d-4ef2-43cd-a941-198cd701cfb4" />

I also added test coverage on a deeply nested merge operation.