### PR TITLE
chore: change Namespace.add to always merge into Namespaces already in graph

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -208,15 +208,15 @@ Namespace.prototype.getEnum = function getEnum(name) {
     throw Error("no such enum: " + name);
 };
 
-function mergeNamespaces({ host, donor }) {
+function mergeNamespaces({ recipient, donor }) {
     var nested = donor.nestedArray;
     for (var i = 0; i < nested.length; ++i) {
-        host.add(nested[i]);
+        recipient.add(nested[i]);
     }
     if (donor.parent) {
         donor.parent.remove(donor);
     }
-    host.setOptions(donor.options, true);
+    recipient.setOptions(donor.options, true);
 }
 
 /**
@@ -227,25 +227,25 @@ function mergeNamespaces({ host, donor }) {
  * @throws {Error} If there is already a nested object with this name
  */
 Namespace.prototype.add = function add(object) {
+
     if (!(object instanceof Field && object.extend !== undefined || object instanceof Type  || object instanceof OneOf || object instanceof Enum || object instanceof Service || object instanceof Namespace))
         throw TypeError("object must be a valid nested object");
 
-    var reusing = false;
+    var merged = false;
     if (!this.nested)
         this.nested = {};
     else {
         var prev = this.get(object.name);
         if (prev) {
             if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
-                // we're going to keep using `prev`
-                reusing = true;
-                mergeNamespaces({ host: prev, donor: object });
+                merged = true;
+                mergeNamespaces({ recipient: prev, donor: object });
             } else
                 throw Error("duplicate name '" + object.name + "' in " + this);
         }
     }
 
-    if (!reusing) {
+    if (!merged) {
         this.nested[object.name] = object;
         object.onAdd(this);
         clearCache(this);

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -208,6 +208,14 @@ Namespace.prototype.getEnum = function getEnum(name) {
     throw Error("no such enum: " + name);
 };
 
+function mergeNamespaces({ host, donor }) {
+    var nested = donor.nestedArray;
+    for (var i = 0; i < nested.length; ++i)
+        host.add(nested[i]);
+    if (donor.parent) donor.parent.remove(donor);
+    host.setOptions(donor.options, true);
+}
+
 /**
  * Adds a nested object to this namespace.
  * @param {ReflectionObject} object Nested object to add
@@ -228,14 +236,7 @@ Namespace.prototype.add = function add(object) {
             if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
                 // we're going to keep using `prev`
                 reusing = true;
-                // replace plain namespace but keep existing nested elements and options
-                var nested = object.nestedArray;
-                for (var i = 0; i < nested.length; ++i)
-                    prev.add(nested[i]);
-                if (object.parent) object.parent.remove(object);
-                if (!this.nested)
-                    this.nested = {};
-                prev.setOptions(object.options, true);
+                mergeNamespaces({ host: prev, donor: object });
             } else
                 throw Error("duplicate name '" + object.name + "' in " + this);
         }

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -216,31 +216,35 @@ Namespace.prototype.getEnum = function getEnum(name) {
  * @throws {Error} If there is already a nested object with this name
  */
 Namespace.prototype.add = function add(object) {
-
     if (!(object instanceof Field && object.extend !== undefined || object instanceof Type  || object instanceof OneOf || object instanceof Enum || object instanceof Service || object instanceof Namespace))
         throw TypeError("object must be a valid nested object");
 
+    var reusing = false;
     if (!this.nested)
         this.nested = {};
     else {
         var prev = this.get(object.name);
         if (prev) {
             if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
+                // we're going to keep using `prev`
+                reusing = true;
                 // replace plain namespace but keep existing nested elements and options
-                var nested = prev.nestedArray;
+                var nested = object.nestedArray;
                 for (var i = 0; i < nested.length; ++i)
-                    object.add(nested[i]);
-                this.remove(prev);
+                    prev.add(nested[i]);
+                if (object.parent) object.parent.remove(object);
                 if (!this.nested)
                     this.nested = {};
-                object.setOptions(prev.options, true);
-
+                prev.setOptions(object.options, true);
             } else
                 throw Error("duplicate name '" + object.name + "' in " + this);
         }
     }
-    this.nested[object.name] = object;
-    object.onAdd(this);
+
+    if (!reusing) {
+        this.nested[object.name] = object;
+        object.onAdd(this);
+    }
     return clearCache(this);
 };
 

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -210,9 +210,12 @@ Namespace.prototype.getEnum = function getEnum(name) {
 
 function mergeNamespaces({ host, donor }) {
     var nested = donor.nestedArray;
-    for (var i = 0; i < nested.length; ++i)
+    for (var i = 0; i < nested.length; ++i) {
         host.add(nested[i]);
-    if (donor.parent) donor.parent.remove(donor);
+    }
+    if (donor.parent) {
+        donor.parent.remove(donor);
+    }
     host.setOptions(donor.options, true);
 }
 
@@ -245,8 +248,9 @@ Namespace.prototype.add = function add(object) {
     if (!reusing) {
         this.nested[object.name] = object;
         object.onAdd(this);
+        clearCache(this);
     }
-    return clearCache(this);
+    return this;
 };
 
 /**

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -131,3 +131,90 @@ tape.test("reflected namespaces", function(test) {
 
     test.end();
 });
+
+tape.test("namespace merging with nested namespaces", function(test) {
+
+    // Create a root namespace
+    var root = new protobuf.Root();
+
+    // Create first namespace using fromJSON with company.org.team structure
+    root.addJSON({
+        company: {
+            nested: {
+                org: {
+                    nested: {
+                        team: {
+                            nested: {
+                                sales: {
+                                    fields: {
+                                        name: { type: "string", id: 1 },
+                                        id: { type: "int32", id: 2 }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Create second namespace using fromJSON with same company.org.team structure
+    var companyNS2 = protobuf.Namespace.fromJSON("company", {
+        nested: {
+            org: {
+                nested: {
+                    team: {
+                        nested: {
+                            billing: {
+                                fields: {
+                                    name: { type: "string", id: 1 },
+                                    id: { type: "int32", id: 2 }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            org2: {
+                nested: {
+                    squad: {
+                        fields: {
+                            name: { type: "string", id: 1 },
+                            id: { type: "int32", id: 2 }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Store lookups from the root after ingesting json initially
+    const companyOriginal = root.lookup("company");
+    const orgOriginal = root.lookup("company.org");
+    const teamOriginal = root.lookup("company.org.team");
+
+    const orgNS2 = companyNS2.lookup("org");
+    const org2 = companyNS2.lookup("org2");
+    const squad = companyNS2.lookup("org2.squad");
+
+    // add the second namespace to the root, forcing merge
+    root.add(companyNS2);
+
+    // Verify that the original namespaces are still accessible via lookup
+    test.same(root.lookup("company"), companyOriginal, "should still return original company namespace");
+    test.same(root.lookup("company.org"), orgOriginal, "should still return original org namespace");
+    test.same(root.lookup("company.org.team"), teamOriginal, "should still return original team namespace");
+    test.same(root.lookup("company.org.team").nestedArray.map(o => o.name), ['sales', 'billing'], "merged team children are both present");
+
+    // merge resulted in companyNS2 and orgNS2 being discarded.
+    test.equal(companyNS2.parent, null, "companyNS2 does not have a parent");
+    test.equal(orgNS2.parent, null, "orgNS2 does not have a parent");
+
+    // org2 should have been added as-is to companyOriginal
+    test.equal(org2.parent, companyOriginal, "org2 parent is now companyOriginal");
+    test.equal(squad.parent, org2, "squad parent is still org2");
+    test.same(root.lookup('company.org2.squad'), squad, "the squad object is accessible from root");
+
+    test.end();
+});


### PR DESCRIPTION
For a call like

```js
leftNamespace.add(rightNamespace)
```

the **current** logic will merge immediate children of the left namespace into matches found in the right namespace. It then makes the recursive `add` call **flipping the children** for the "right" namespace to be the "left".

The resulting merged graph has _odd_ level children from the `rightNamespace` graph and _even_ level children from the `leftNamespace` graph (the graphs are merged, so redundant Namespace objects are being discarded on alternating sides)

```
leftNamespace (root)
 -> Level 1 namespace children from rightNamespace graph
 -> Level 2 namespace children from leftNameSpace graph
 -> Level 3 namespace children from rightNamespace graph
 ...etc
```

This works, but IMO it seems more confusing than keeping the left side always the left. Keeping the original structure makes writing tests against the results of `add` operations more predictable, and in our usage it may also result in a dece nt reduction of loop iterations as the left namespace graph grows to have [many children of](https://github.com/squareup/dashboard/tree/main/frontend/%40square/dashboard-protos/addon/models/squareup) `squareup`.

---

## Other notes

In the diff you can see that the
```js
if (!this.nested)
  this.nested = {};
```

code is gone in the refactor. This is because the recipient parent will not be modified, because we don't remove anything from it. In the original version of this code, calling `this.remove(prev)` resulted in the `this` namespace possibly no longer have anything in its `nested` because of `delete this.nested[object.name];` in the remove method. By keeping the left hand side, we avoid this possibility. The Namespaces on the donor side are getting disconnected and shouldn't be used anymore, so I don't think there's a case where anyone would care about setting the empty array back up on `donor.parent.nested`. 